### PR TITLE
Fix slopcursion section - add iframe close tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -751,6 +751,7 @@
 			<section id="slopcursion">
 			<h2>So you can Slopify while you Slopify</h2>
 			<iframe src="index.html?slopcursion=true" width="100%" height="500px" frameborder="0">
+      </iframe>
 			</section>
       <section>
         <h2>oh hewwo thewe, you gwot twhis fwar uwu~! wouwd you wike to wead somethin’ awesome~? >w<</h2>


### PR DESCRIPTION
The "Slopcursion" section doesn't have an iframe close tag so any sections added afterwards are suppressed, this adds a close tag to the iframe and enables sections added below in index.html