### PR TITLE
Fix Windows95 popup bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
 		<link rel="apple-touch-icon" sizes="128x128" href="/static/images/apple-touch-icon.png">
     <link rel="icon" type="image/x-icon" href="/static/images/favicon.ico">
     <link rel="stylesheet" href="static/css/page-nav.css">
+    <link rel="stylesheet" href="static/css/error.css">
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.2.3/howler.min.js"></script>
 
 	<style>
 


### PR DESCRIPTION
Previous version had JavaScript code within `<style>` tag (for example, [Line #52 in index.html](https://github.com/DishpitDev/Slopify/blob/3d0b428b247e7021078871768feb4526c5843b31/index.html#L52)) and [static/css/error.css](https://github.com/DishpitDev/Slopify/blob/main/static/css/error.css) stylesheet was removed from `index.html`, which broke Windows95 popup functionality (i.e. Windows95 popups no longer appeared).

Windows95-related bugs have been fixed (i.e. stylesheet added back and JavaScript library added outside of `<style>` tag).

**Before (i.e. Current Version)**
<img alt="Before version" src="https://github.com/user-attachments/assets/18fcf42b-a809-4dcd-a8af-89f0d41bafdd" />

**After (i.e. Fixed Update)**
<img alt="After version" src="https://github.com/user-attachments/assets/1abdf01a-82e7-4ee7-a416-1c9a8bd3614e" />