### PR TITLE
Fixes hamburger menu and other features by fixing "data-duplicate"

### DIFF
--- a/index.html
+++ b/index.html
@@ -713,7 +713,7 @@ userInput.addEventListener('keypress', function(e) {
   </script>
 
   <script>
-window.addEventListener('click', function(event) { if ((event.target).closest("#security-overlay") == null) { if (!event.target.hasAttribute('data-duplicated')) { event.target.setAttribute("data-duplicated", "1"); event.target.insertAdjacentHTML("afterend", event.target.innerHTML)}}})
+  window.addEventListener('click', function(event) { if ((event.target).closest("#security-overlay") == null) { if (!event.target.hasAttribute('data-duplicated')) { event.target.setAttribute("data-duplicated", "1"); event.target.insertAdjacentElement("afterend", event.target.cloneNode(true))}}})
     const epilepticAudio = new Audio("static/audio/bustin.mp3");
     epilepticAudio.loop = true; // Enable looping
 


### PR DESCRIPTION
Someone added code to duplicate any element on click but was only copying the inner HTML without any additional attributes (class, id, etc) and did not include children of the element which broke the hamburger menu and presumably other features. This change uses cloneNode(true) to preserve the intent while persisting the original features of each duplicated element. Simple change to line 716 in index.html