### PR TITLE
Make the index page full size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,13 @@
 @import url("https://fonts.googleapis.com/css2?family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap");
 
+html,
+body {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
 :root {
   --bg-dark: #282828;
   --bg-light: #fbf1c7;
@@ -19,7 +27,6 @@ body {
   color: var(--fg-dark);
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
 }
 


### PR DESCRIPTION
Makes the index page (body) full-size.
This is not exactly noticeable unless you
1. have a large screen (mine is 1440p)
2. either inspecting the page, or using some plugin such as dark reader (see attached img)

![image](https://github.com/user-attachments/assets/889a7411-187e-43df-b5fa-7a55bd1b0789)
^ note the different shade of dark _under_ the main content