### PR TITLE
Contributors list

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,6 +1,7 @@
 name: Update Contributors
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - mommy

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,0 +1,42 @@
+name: Update Contributors
+
+on:
+  push:
+    branches:
+      - mommy
+
+jobs:
+  update-contributors:
+    if: github.event.before != github.event.after && github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run fetch-contributors.py
+        run: python fetch-contributors.py
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git diff --exit-code contributors.json || echo "changes"
+
+      - name: Commit and push changes
+        if: steps.check_changes.outputs.changes == 'changes'
+        run: |
+          git add contributors.json
+          git commit -m "Update contributors.json"
+          git push origin mommy

--- a/README.md
+++ b/README.md
@@ -69,3 +69,6 @@ For contributing, check **[CONTRIBUTING.md](https://github.com/DishpitDev/Slopif
 - “Twittermoanials” section (Twitter-style testimonials)
 - Locked In Alien video in Windows95-style media player in every 404 (i.e. non-existant) page, e.g. [https://slopify.dev/404-420-69](https://slopify.dev/404-420-69)
 - Personal diary of a certain Miz (me)
+
+<!-- CONTRIBUTORS:START -->
+<!-- CONTRIBUTORS:END -->

--- a/fetch-contributors.py
+++ b/fetch-contributors.py
@@ -1,0 +1,30 @@
+import requests
+import json
+
+
+BASE_API_URL = 'https://api.github.com/repos/DishpitDev/Slopify'
+
+
+def fetch_contributors():
+    page = 1
+    fetched_contributors = []
+    all_contributors = []
+
+    while page == 1 or fetched_contributors:
+        url = f'{BASE_API_URL}/contributors?per_page=100&page={page}'
+        response = requests.get(url)
+        fetched_contributors = response.json()
+        all_contributors += fetched_contributors
+        page += 1
+
+    return all_contributors
+
+
+def main():
+    contributors = fetch_contributors()
+    with open('contributors.json', 'w') as f:
+        json.dump(contributors, f)
+
+
+if __name__ == '__main__':
+    main()

--- a/fetch-contributors.py
+++ b/fetch-contributors.py
@@ -1,6 +1,7 @@
+import re
+import sys
 import requests
 import json
-
 
 BASE_API_URL = 'https://api.github.com/repos/DishpitDev/Slopify'
 
@@ -20,10 +21,35 @@ def fetch_contributors():
     return all_contributors
 
 
+def get_rounded_img_url(url, size=64):
+    return f'https://images.weserv.nl/?url={url}?h={size}&w={size}&fit=cover&mask=circle'
+
+
+def create_contributor_badge(contributor):
+    return f'<a href="{contributor["html_url"]}"><img src="{get_rounded_img_url(contributor["avatar_url"])}" alt="{contributor["login"]}"></a>'
+
+
+def modify_readme(readme, contributors):
+    badges = '\n'.join([create_contributor_badge(contributor) for contributor in contributors])
+
+    readme = re.sub(r'<!-- CONTRIBUTORS:START -->.*<!-- CONTRIBUTORS:END -->',
+                    f'<!-- CONTRIBUTORS:START -->\n# Contributors ({len(contributors)})\n\n{badges}\n<!-- CONTRIBUTORS:END -->',
+                    readme, flags=re.DOTALL)
+
+    with open('readme.md', 'w', encoding='utf-8') as f:
+        f.write(readme)
+
+
 def main():
     contributors = fetch_contributors()
     with open('contributors.json', 'w') as f:
         json.dump(contributors, f)
+
+    with open('readme.md', 'r', encoding='utf-8') as f:
+        readme = f.read()
+
+    if '--readme' in sys.argv:
+        modify_readme(readme, contributors)
 
 
 if __name__ == '__main__':

--- a/fetch-contributors.py
+++ b/fetch-contributors.py
@@ -29,14 +29,17 @@ def create_contributor_badge(contributor):
     return f'<a href="{contributor["html_url"]}"><img src="{get_rounded_img_url(contributor["avatar_url"])}" alt="{contributor["login"]}"></a>'
 
 
-def modify_readme(readme, contributors):
+def modify_readme(contributors):
+    with open('README.md', 'r', encoding='utf-8') as f:
+        readme = f.read()
+
     badges = '\n'.join([create_contributor_badge(contributor) for contributor in contributors])
 
     readme = re.sub(r'<!-- CONTRIBUTORS:START -->.*<!-- CONTRIBUTORS:END -->',
                     f'<!-- CONTRIBUTORS:START -->\n# Contributors ({len(contributors)})\n\n{badges}\n<!-- CONTRIBUTORS:END -->',
                     readme, flags=re.DOTALL)
 
-    with open('readme.md', 'w', encoding='utf-8') as f:
+    with open('README.md', 'w', encoding='utf-8') as f:
         f.write(readme)
 
 
@@ -45,11 +48,8 @@ def main():
     with open('contributors.json', 'w') as f:
         json.dump(contributors, f)
 
-    with open('readme.md', 'r', encoding='utf-8') as f:
-        readme = f.read()
-
     if '--readme' in sys.argv:
-        modify_readme(readme, contributors)
+        modify_readme(contributors)
 
 
 if __name__ == '__main__':

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Slopify - The Ideomotor effect of software</title>
     <link rel="stylesheet" href="styles.css" />
+    <script src="script.js"></script>
   </head>
 
   <body>
@@ -127,6 +128,12 @@
           Download for macOS
         </a>
       </div>
+
+      <div class="contributors-section">
+        <h3>Contributors</h3>
+        <p>All this slop was sloppified by these sloppy individuals.</p>
+      </div>
+      <div id="contributors" class="contributors-grid"></div>
     </section>
 
     <footer>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,34 @@
+/* The contributors are loaded from a file instead of being fetched from the GitHub API.
+ * This is done to avoid rate limiting, since the GitHub API has a limit of 60 requests per hour.
+ * The contributors.json file is generated from the fetch-contributors.py script.
+ */
+const setup_contributors = () => {
+  const contributors = document.getElementById("contributors");
+
+  fetch("contributors.json")
+    .then((response) => response.json())
+    .then((data) => {
+      data.forEach((contributor) => {
+        const img = document.createElement("img");
+        img.src = contributor.avatar_url;
+        img.width = 64;
+        img.height = 64;
+
+        const a = document.createElement("a");
+        a.href = contributor.html_url;
+        a.appendChild(img);
+
+        const div = document.createElement("div");
+        div.appendChild(a);
+
+        contributors.appendChild(div);
+      });
+    })
+    .catch((error) => {
+      contributors.innerHTML = "Failed to load contributors";
+      contributors.className = "error";
+      console.error(error);
+    });
+};
+
+document.addEventListener("DOMContentLoaded", setup_contributors);

--- a/styles.css
+++ b/styles.css
@@ -2,10 +2,13 @@
 
 html,
 body {
-  height: 100%;
-  width: 100%;
   margin: 0;
   padding: 0;
+}
+
+html {
+  min-width: fit-content;
+  min-height: fit-content;
 }
 
 :root {
@@ -13,6 +16,8 @@ body {
   --bg-light: #fbf1c7;
   --fg-dark: #ebdbb2;
   --fg-light: #3c3836;
+  --bg-green: #b8bb26;
+  --bg-gold: #d79921;
   --accent-blue: #83a598;
   --accent-green: #8ec07c;
   --accent-red: #fb4934;
@@ -20,6 +25,8 @@ body {
 }
 
 body {
+  height: 100%;
+  width: 100%;
   font-family: "Ubuntu Mono", serif;
   margin: 0;
   padding: 0;
@@ -31,8 +38,8 @@ body {
 }
 
 header {
-  background-color: #b8bb26;
-  color: #282828;
+  background-color: var(--bg-green);
+  color: var(--bg-dark);
   padding: 20px 0;
   text-align: center;
   width: 100%;
@@ -62,17 +69,17 @@ header p {
 .leaderboard th,
 .leaderboard td {
   padding: 10px;
-  border: 1px solid #ebdbb2;
+  border: 1px solid var(--fg-dark);
   text-align: left;
 }
 
 .leaderboard th {
-  background-color: #b8bb26;
-  color: #282828;
+  background-color: var(--bg-green);
+  color: var(--bg-dark);
 }
 
 .leaderboard td {
-  background-color: #3c3836;
+  background-color: var(--fg-light);
 }
 
 .download-btns {
@@ -84,8 +91,8 @@ header p {
 }
 
 .download-btn {
-  background-color: #d79921;
-  color: #282828;
+  background-color: var(--bg-gold);
+  color: var(--bg-dark);
   font-size: 16px;
   padding: 15px 30px;
   border: none;
@@ -101,7 +108,7 @@ header p {
 }
 
 .download-btn:hover {
-  background-color: #fabd2f;
+  background-color: var(--accent-yellow);
 }
 
 .download-btn img {
@@ -130,7 +137,7 @@ a {
 }
 
 a:hover {
-  color: #d79921;
+  color: var(--bg-gold);
   text-decoration: underline;
 }
 
@@ -142,7 +149,7 @@ footer {
 }
 
 footer a {
-  color: #d79921;
+  color: var(--bg-gold);
   text-decoration: none;
 }
 
@@ -195,4 +202,34 @@ footer a:hover {
 
 .season-link:hover {
   background-color: var(--accent-yellow);
+}
+
+.contributors-grid {
+  display: grid;
+  grid-template-columns: repeat(10, minmax(0, 1fr));
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+#contributors p {
+  font-size: 1.2rem;
+  color: var(--fg-light);
+  text-align: center;
+}
+
+#contributors img {
+  width: 100%;
+  border-radius: 50%;
+  transition: transform 0.2s ease-in-out;
+  border: 2px solid var(--accent-blue);
+}
+
+#contributors img:hover {
+  transform: scale(1.2);
+}
+
+.error {
+  color: var(--accent-red);
+  font-size: 1.2rem;
+  text-align: center;
 }


### PR DESCRIPTION
With this PR, there's now a script that fetches all the contributors from the repo and adds them both to the site, and the README (this part is optional/configurable).
However, to avoid spamming the GitHub API, I create a file locally: `contributors.json`. This file is not included.
I want some thoughts on this? Should we include it, and update it with GH actions, or is there something that can be done on the backend (vercel, or wherever it's being hosted)?

![t7hMUx3h63](https://github.com/user-attachments/assets/79ed6cd0-c9c6-423d-906a-5f2c5d3a27ac)
![librewolf_aWcyDO6i2L](https://github.com/user-attachments/assets/d893f937-8d97-45e7-a455-4bda71a51ccf)
